### PR TITLE
add support for win32 build

### DIFF
--- a/include/linux-err.h
+++ b/include/linux-err.h
@@ -2,27 +2,31 @@
 #define __must_check __attribute__((__warn_unused_result__))
 #define __force
 
+#ifndef _WIN32
+#include <stdint.h>
+#endif
+
 #define MAX_ERRNO	4095
 
-#define IS_ERR_VALUE(x) ((unsigned long)(void *)(x) >= (unsigned long)-MAX_ERRNO)
+#define IS_ERR_VALUE(x) ((uintptr_t)(void *)(x) >= (uintptr_t)-MAX_ERRNO)
 
 
-static inline void * __must_check ERR_PTR(long error)
+static inline void * __must_check ERR_PTR(intptr_t error)
 {
 	return (void *) error;
 }
 
-static inline long __must_check PTR_ERR(__force const void *ptr)
+static inline intptr_t __must_check PTR_ERR(__force const void *ptr)
 {
-	return (long) ptr;
+	return (intptr_t) ptr;
 }
 
 static inline bool __must_check IS_ERR(__force const void *ptr)
 {
-	return IS_ERR_VALUE((unsigned long)ptr);
+	return IS_ERR_VALUE((uintptr_t)ptr);
 }
 
 static inline bool __must_check IS_ERR_OR_NULL(__force const void *ptr)
 {
-	return (!ptr) || IS_ERR_VALUE((unsigned long)ptr);
+	return (!ptr) || IS_ERR_VALUE((uintptr_t)ptr);
 }

--- a/include/linux-types.h
+++ b/include/linux-types.h
@@ -1,4 +1,17 @@
 #pragma once
+
+#ifdef _WIN32
+#include <stdint.h>
+typedef int8_t  s8;
+typedef uint8_t  u8;
+typedef int16_t s16;
+typedef uint16_t u16;
+typedef int32_t s32;
+typedef uint32_t u32;
+typedef int64_t s64;
+typedef uint64_t u64;
+typedef s64 loff_t;
+#else
 #include <linux/types.h>
 typedef __s8  s8;
 typedef __u8  u8;
@@ -8,6 +21,7 @@ typedef __s32 s32;
 typedef __u32 u32;
 typedef __s64 s64;
 typedef __u64 u64;
+#endif
 
 #define container_of(ptr, type, member) ({				\
 	void *__mptr = (void *)(ptr);					\
@@ -15,7 +29,7 @@ typedef __u64 u64;
 
 #define BIT(_B) (1 << (_B))
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
-#define BITS_PER_LONG (sizeof(long) * 8)
+#define BITS_PER_LONG (sizeof(intptr_t) * 8)
 #define GENMASK(h, l) \
-	(((~0LU) - (1LU << (l)) + 1) & \
-	 (~0LU >> (BITS_PER_LONG - 1 - (h))))
+	((uintptr_t)(((~0ULL) - (1ULL << (l)) + 1) & \
+	 (~0ULL >> (BITS_PER_LONG - 1 - (h)))))

--- a/include/nand.h
+++ b/include/nand.h
@@ -17,6 +17,10 @@
 #include <errno.h>
 #include <linux-types.h>
 
+#ifdef _WIN32
+#define __always_inline	inline __attribute__((__always_inline__))
+#endif
+
 #define do_div(n,base) ({					\
 	uint32_t __base = (base);				\
 	uint32_t __rem;						\

--- a/include/spi-mem.h
+++ b/include/spi-mem.h
@@ -18,7 +18,11 @@
 #include <linux-types.h>
 #include <linux-err.h>
 
+#ifdef _WIN32
+typedef intptr_t ssize_t;
+#else
 typedef long ssize_t;
+#endif
 struct spi_controller_mem_ops;
 
 #define SPI_MEM_OP_CMD(__opcode, __buswidth)			\

--- a/spi-mem/ch347/ch347.h
+++ b/spi-mem/ch347/ch347.h
@@ -13,7 +13,9 @@
 extern "C" {
 #endif
 
+#ifndef _WIN32
 #include <endian.h>
+#endif
 #include <stdint.h>
 #include <stdbool.h>
 #include <libusb-1.0/libusb.h>

--- a/spi-mem/spi-mem-drvs.c
+++ b/spi-mem/spi-mem-drvs.c
@@ -7,8 +7,10 @@ struct spi_mem *spi_mem_probe(const char *drv, const char *drvarg) {
         return ch347_probe();
     if (!strcmp(drv, "fx2qspi"))
         return fx2qspi_probe();
+#ifndef _WIN32
     if (!strcmp(drv, "serprog"))
         return serprog_probe(drvarg);
+#endif
     return NULL;
 }
 
@@ -17,6 +19,8 @@ void spi_mem_remove(const char *drv, struct spi_mem *mem) {
         return ch347_remove(mem);
     if (!strcmp(drv, "fx2qspi"))
         return fx2qspi_remove(mem);
+#ifndef _WIN32
     if (!strcmp(drv, "serprog"))
         return serprog_remove(mem);
+#endif
 }

--- a/spi-mem/spi-mem-serprog.c
+++ b/spi-mem/spi-mem-serprog.c
@@ -1,3 +1,4 @@
+#ifndef _WIN32
 #include <spi-mem.h>
 #include <serprog.h>
 #include <linux-types.h>
@@ -335,3 +336,4 @@ void serprog_remove(struct spi_mem *mem)
 {
 	close(serial_fd);
 }
+#endif


### PR DESCRIPTION
modify some header and type to support building for windows platform. currently serprog is disabled on windows since all the operations on serial needs to be abstracted for both linux and windows.